### PR TITLE
rioxarray 0.18.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
   description: |
     rasterio xarray extension.
   doc_url: https://corteva.github.io/rioxarray
-  dev_url: http://github.com/corteva/rioxarray
+  dev_url: https://github.com/corteva/rioxarray
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rioxarray" %}
-{% set version = "0.17.0" %}
+{% set version = "0.18.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,28 +7,33 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 46c29938827fff268d497f7ae277077066fcfbac4e53132ed3d4e2b96455be62
+  sha256: 62bdef2a1ae8ac1de8cd3e809bfe3c8c5d09d1edc873ef9b1f373d37cf8da02b
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.10
-    - rasterio >=1.3
+    - python
+    - rasterio >=1.3.7
     - scipy
-    - xarray >=2022.3.0
+    - xarray >=2024.7.0
     - pyproj >=3.3
     - packaging
     - numpy >=1.23
 test:
   imports:
     - rioxarray
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: http://github.com/corteva/rioxarray
@@ -36,7 +41,8 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: rasterio xarray extension.
-  description: rasterio xarray extension.
+  description: |
+    rasterio xarray extension.
   doc_url: https://corteva.github.io/rioxarray
   dev_url: http://github.com/corteva/rioxarray
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310 and s390x]
+  skip: true  # [py<310 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 #  s390x is currently unavailable for rasterio so we will skip this platform for now.
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310]
+  skip: true  # [py<310 and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-
+#  s390x is currently unavailable for rasterio so we will skip this platform for now.
 requirements:
   host:
     - python
@@ -37,7 +37,7 @@ test:
     - pip
 
 about:
-  home: http://github.com/corteva/rioxarray
+  home: https://github.com/corteva/rioxarray
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE


### PR DESCRIPTION
> ## ☆rioxarray 0.18.1☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5057)
[Upstream](https://github.com/corteva/rioxarray/tree/0.18.1)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Amendments to `about` section
