### PR TITLE
rioxarray 0.22.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,19 +33,13 @@ test:
     - test/
   commands:
     - pip check
-    # Segfault in GDAL via rioxarray._io._load_subdatasets on Apple Silicon (see test_open_multiple_resolution).
-    # - pytest -v test/ -k "not test_open_multiple_resolution"  # [osx and arm64]
-    # - pytest -v test/  # [not (osx and arm64)]
-    - pytest -v test/
+    # Integration tests under test/integration/ hit real files (GeoTIFF, NetCDF, HDF, MODIS,
+    # etc.) and assume a GDAL/rasterio/xarray/PROJ which is quite hard to match versions
+    # since not specified by upstream.
+    - pytest -v test/unit/
   requires:
     - pip
     - pytest >=3.6
-    # NumPy 2 removed np.float; older dask fails at import (see dask/array/numpy_compat.py)
-    - dask >=2024.8
-    - netcdf4
-    # GDAL format plugins for rasterio (must match libgdal from rasterio)
-    - libgdal-hdf5
-    - libgdal-hdf4
 
 about:
   home: https://corteva.github.io/rioxarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "rioxarray" %}
-{% set version = "0.18.1" %}
+{% set version = "0.22.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 62bdef2a1ae8ac1de8cd3e809bfe3c8c5d09d1edc873ef9b1f373d37cf8da02b
+  url: https://github.com/corteva/{{ name }}/archive/refs/tags/{{ version}}.tar.gz
+  sha256: 104bd13d69475b8a7303ed90d9a2ca4000aba154f916dce4d6b9bbe778edd5e5
 
 build:
-  number: 1
-  skip: true  # [py<310]
+  number: 0
+  skip: true  # [py<312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 requirements:
   host:
@@ -21,26 +21,30 @@ requirements:
     - wheel
   run:
     - python
-    - rasterio >=1.3.7
-    - scipy
-    - xarray >=2024.7.0
-    - pyproj >=3.3
     - packaging
-    - numpy >=1.23
+    - rasterio >=1.4.3
+    - xarray >=2026.2
+    - pyproj >=3.3
+    - numpy >=2
 test:
   imports:
     - rioxarray
+  source_files:
+    - test/
   commands:
     - pip check
+    - pytest -v test/
   requires:
     - pip
+    - pytest >=3.6
+    - dask
 
 about:
-  home: https://github.com/corteva/rioxarray
+  home: https://corteva.github.io/rioxarray
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: rasterio xarray extension.
+  summary: geospatial xarray extension powered by rasterio
   description: |
     rasterio xarray extension.
   doc_url: https://corteva.github.io/rioxarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,9 @@ source:
   sha256: 62bdef2a1ae8ac1de8cd3e809bfe3c8c5d09d1edc873ef9b1f373d37cf8da02b
 
 build:
-  number: 0
-  skip: true  # [py<310 or s390x]
+  number: 1
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-#  s390x is currently unavailable for rasterio so we will skip this platform for now.
 requirements:
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,11 +33,18 @@ test:
     - test/
   commands:
     - pip check
+    # Segfault in GDAL via rioxarray._io._load_subdatasets on Apple Silicon (see test_open_multiple_resolution).
+    # - pytest -v test/ -k "not test_open_multiple_resolution"  # [osx and arm64]
+    # - pytest -v test/  # [not (osx and arm64)]
     - pytest -v test/
   requires:
     - pip
     - pytest >=3.6
     - dask
+    - netcdf4
+    # GDAL format plugins for rasterio (must match libgdal from rasterio)
+    - libgdal-hdf5
+    - libgdal-hdf4
 
 about:
   home: https://corteva.github.io/rioxarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ test:
   requires:
     - pip
     - pytest >=3.6
-    - dask
+    # NumPy 2 removed np.float; older dask fails at import (see dask/array/numpy_compat.py)
+    - dask >=2024.8
     - netcdf4
     # GDAL format plugins for rasterio (must match libgdal from rasterio)
     - libgdal-hdf5


### PR DESCRIPTION
rioxarray 0.22.0 

**Destination channel:** Defaults

### Links

- [PKG-12076]
- dev_url:        https://github.com/corteva/rioxarray/tree/0.22.0
- conda_forge:    https://github.com/conda-forge/rioxarray-feedstock
- pypi:           https://pypi.org/project/rioxarray/0.22.0
- pypi inspector: https://inspector.pypi.io/project/rioxarray/0.22.0

### Explanation of changes:

- new version number
- add py314
- add testing (no `test/` folder in pypi package)

[PKG-12076]: https://anaconda.atlassian.net/browse/PKG-12076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ